### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require":{
         "php": "~5.5.0|~5.6.0|~7.0.0",
-        "magento/zendframework1": "1.12.16",
+        "magento/zendframework1": "~1.12.0",
         "colinmollenhour/credis":"1.6"
 
     },


### PR DESCRIPTION
As Magento ZF1 fork in 1.12.16 version has security issue we need to update Magento ZF1 fork, to bypass this variants in future we need to change version to "~1.12.0" which means  >=1.12.0-dev <1.13.0-dev