### PR TITLE
Remove magento/zendframework1 from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require":{
         "php": "~5.5.0|~5.6.0|~7.0.0",
-        "magento/zendframework1": "~1.12.0",
         "colinmollenhour/credis":"~1.6"
     },
     "autoload": {


### PR DESCRIPTION
magento/zendframework1 is an m2 dep, I don't think you want it installed
if you're using m1