### PR TITLE
Remove dependency on zend framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require":{
         "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
-        "magento/zendframework1": "~1.12.0",
         "colinmollenhour/credis":"1.6"
 
     },


### PR DESCRIPTION
As I see, Zend framework is actually never used in v1.2.x of this library and already dropped in the v1.3.x. It would be nice to remove this dependency for v.1.2.x too as it locks specific zend framework version without a reason.