### PR TITLE
Fix deadlock when using `session_start(array("read_and_close"=>true))`

### DIFF
--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -666,6 +666,21 @@ class Handler implements \SessionHandlerInterface
      */
     public function close()
     {
+        $id = session_id();
+        $sessionId = 'sess_' . $id;
+
+        if ( ! $this->_useLocking
+            || ( ! ($pid = $this->_redis->hGet('sess_'.$sessionId, 'pid')) || $pid == $this->_getPid())
+        ) {
+            $this->_redis->pipeline()
+                ->select($this->_dbNum)
+                ->hMSet($sessionId, array(
+                    'lock' => 0, // 0 so that next lock attempt will get 1
+                ))
+                ->expire($sessionId, min($this->getLifeTime(), $this->_maxLifetime))
+                ->exec();
+        }
+
         $this->_log("Closing connection");
         if ($this->_redis) $this->_redis->close();
         return true;


### PR DESCRIPTION
This might not be the best.

The weird thing is that `close()` doesn't provide the `session_id()` which we need to release the lock. 

This makes me think this isn't the right place to release the lock, and `read()` should probably make sure it releases the lock when it's called with "read_and_close".