### PR TITLE
Add ability to disable locking for bots only

### DIFF
--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -284,7 +284,7 @@ class Handler implements \SessionHandlerInterface
         $this->_failAfter =             $this->config->getFailAfter() ?: self::DEFAULT_FAIL_AFTER;
         $this->_maxLifetime =           $this->config->getMaxLifetime() ?: self::DEFAULT_MAX_LIFETIME;
         $this->_minLifetime =           $this->config->getMinLifetime() ?: self::DEFAULT_MIN_LIFETIME;
-        $this->_useLocking =            ! $this->config->getDisableLocking();
+        $this->_useLocking =            $this->getUseLocking();
 
         // Use sleep time multiplier so fail after time is in seconds
         $this->_failAfter = (int) round((1000000 / self::SLEEP_TIME) * $this->_failAfter);
@@ -726,7 +726,7 @@ class Handler implements \SessionHandlerInterface
             // Detect bots by user agent
             $botLifetime = is_null($this->config->getBotLifetime()) ? self::DEFAULT_BOT_LIFETIME : $this->config->getBotLifetime();
             if ($botLifetime) {
-                $userAgent = empty($_SERVER['HTTP_USER_AGENT']) ? false : $_SERVER['HTTP_USER_AGENT'];
+                $userAgent = $this->getUserAgent();
                 if (self::isBotAgent($userAgent)) {
                     $this->_log(sprintf("Bot detected for user agent: %s", $userAgent));
                     $botFirstLifetime = is_null($this->config->getBotFirstLifetime()) ? self::DEFAULT_BOT_FIRST_LIFETIME : $this->config->getBotFirstLifetime();
@@ -881,5 +881,25 @@ class Handler implements \SessionHandlerInterface
         }
 
         return $this->_breakAfter;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function getUseLocking()
+    {
+        $userAgent = $this->getUserAgent();
+        if (self::isBotAgent($userAgent)) {
+            return ! $this->config->getBotDisableLocking();
+        }
+        return ! $this->config->getDisableLocking();
+    }
+
+    /**
+     * @return string|bool
+     */
+    protected function getUserAgent()
+    {
+        return empty($_SERVER['HTTP_USER_AGENT']) ? false : $_SERVER['HTTP_USER_AGENT'];
     }
 }

--- a/src/Cm/RedisSession/Handler/ConfigInterface.php
+++ b/src/Cm/RedisSession/Handler/ConfigInterface.php
@@ -131,6 +131,13 @@ interface ConfigInterface
     public function getDisableLocking();
 
     /**
+     * Disable session locking for bots only
+     *
+     * @return bool
+     */
+    public function getBotDisableLocking();
+
+    /**
      * Get lifetime of session for bots on subsequent writes, 0 to disable
      *
      * @return int


### PR DESCRIPTION
In New Relic I frequently see slow requests stuck trying to read the session due to being caught on the lock. Most of the time these are from bots as they crawl the site at speed.  

I was thinking that the artificially slow request could potentially have some negative SEO effects, especially on Product pages and similar.  

If we had the ability to disable session locking for bots only we could prevent this issue.

I have not had success previously with disabling session locking entirely so was thinking a little more granular control at this level could help out.

Let me know what you think of this idea.