### PR TITLE
Update Handler.php to catch connection errors in sentinel

### DIFF
--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -303,7 +303,7 @@ class Handler implements \SessionHandlerInterface
             for ($i = 0; $i <= $sentinelConnectRetries; $i++) // Try to connect to sentinels in round-robin fashion
             foreach ($servers as $server) {
                 try {
-                    $sentinelClient = new \Credis_Client($server, NULL, $timeout, $persistent);
+                    $sentinelClient = new \Credis_Client($server, $port, $timeout, $persistent);
                     $sentinelClient->forceStandalone();
                     $sentinelClient->setMaxConnectRetries(0);
                     if ($pass) $sentinelClient->auth($pass);
@@ -332,7 +332,7 @@ class Handler implements \SessionHandlerInterface
 
                     $this->_redis = $redisMaster;
                     break 2;
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     unset($sentinelClient);
                     $exception = $e;
                 }


### PR DESCRIPTION
Found that when when sentinel is enabled, and the Redis Client fails to connect. 

This exception isn't being caught:
{"0":"Connection to Redis redis-master-0.redis-headless.demo-namespace:0 failed after 1 failures.Last Error : (11

Also found that the port as NULL in $sentinelClient = new \Credis_Client($server, $port, $timeout, $persistent);
was causing it to be cast to 0 instead of using the default within Credis Client in php7.3