### PR TITLE
replace "DEL" Commands with "UNLINK"

### DIFF
--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -666,7 +666,7 @@ class Handler implements \SessionHandlerInterface
         $this->_log(sprintf("Destroying ID %s", $sessionId));
         $this->_redis->pipeline();
         if($this->_dbNum) $this->_redis->select($this->_dbNum);
-        $this->_redis->del(self::SESSION_PREFIX.$sessionId);
+        $this->_redis->unlink(self::SESSION_PREFIX.$sessionId);
         $this->_redis->exec();
         return true;
     }


### PR DESCRIPTION
This PR replaces DEL Command with UNLINK command.

Details about UNLINK can be found here https://redis.io/commands/unlink .

As noticed here redis/redis#1748 (comment) this will not change the behavior.

As there is no check of Redis version included, it will break Redis Versions < 4.0 through.

As Redis 4.0 was released on 2017-07-14 and Redis 3 went EOL with the Redis 5 on 2018-10-17, I don't expect this being an issue.

See also https://github.com/colinmollenhour/Cm_Cache_Backend_Redis/issues/158 for details.