### PR TITLE
Remove useless php 7.1 an 7.2 sections in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require":{
-        "php": "^5.5 || ^7.0|| ^7.1 || ^7.2",
+        "php": "^5.5 || ^7.0",
         "colinmollenhour/credis":"~1.6"
     },
     "autoload": {


### PR DESCRIPTION
`"php": "^5.5 || ^7.0"` allows to install any 7.x version, more info https://getcomposer.org/doc/articles/versions.md#caret-version-range-