### PR TITLE
Fix PHP 8.1 warning with sentinel

### DIFF
--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -306,7 +306,16 @@ class Handler implements \SessionHandlerInterface
                     $sentinelClient = new \Credis_Client($server, NULL, $timeout, $persistent);
                     $sentinelClient->forceStandalone();
                     $sentinelClient->setMaxConnectRetries(0);
-                    if ($pass) $sentinelClient->auth($pass);
+                    if ($pass) {
+                        try {
+                            $sentinelClient->auth($pass);
+                        } catch (\CredisException $e) {
+                            // Prevent throwing exception if Sentinel has no password set
+                            if($e->getCode() !== 0 || strpos($e->getMessage(),'ERR Client sent AUTH, but no password is set') === false) {
+                                throw $e;
+                            }
+                        }
+                    }
                    
                     $sentinel = new \Credis_Sentinel($sentinelClient);
                     $sentinel

--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -333,7 +333,7 @@ class Handler implements \SessionHandlerInterface
                             if ($pass) $redisMaster->auth($pass);
                             $roleData = $redisMaster->role();
                             if ( ! $roleData || $roleData[0] != 'master') {
-                                throw new Exception('Unable to determine master redis server.');
+                                throw new \Exception('Unable to determine master redis server.');
                             }
                         }
                     }
@@ -341,7 +341,7 @@ class Handler implements \SessionHandlerInterface
 
                     $this->_redis = $redisMaster;
                     break 2;
-                } catch (Exception $e) {
+                } catch (\Exception $e) {
                     unset($sentinelClient);
                     $exception = $e;
                 }

--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -297,7 +297,7 @@ class Handler implements \SessionHandlerInterface
 
         // Connect and authenticate
         if ($sentinelServers && $sentinelMaster) {
-            $servers = preg_split('/\s*,\s*/', trim($sentinelServers), NULL, PREG_SPLIT_NO_EMPTY);
+            $servers = preg_split('/\s*,\s*/', trim($sentinelServers), -1, PREG_SPLIT_NO_EMPTY);
             $sentinel = NULL;
             $exception = NULL;
             for ($i = 0; $i <= $sentinelConnectRetries; $i++) // Try to connect to sentinels in round-robin fashion

--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -349,7 +349,7 @@ class Handler implements \SessionHandlerInterface
             unset($sentinel);
 
             if ( ! $this->_redis) {
-                throw new ConnectionFailedException('Unable to connect to a Redis: '.$exception->getMessage(), $exception);
+                throw new ConnectionFailedException('Unable to connect to a Redis: '.$exception->getMessage(), 0, $exception);
             }
         }
         else {


### PR DESCRIPTION
Resolve warning: Deprecated Functionality: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in /Cm/RedisSession/Handler.php on line 300

EDIT: on Redis 6 the error message returned when AUTH is not set on sentinels is different, so add it to check