### PR TITLE
Support of the separate password for Redis Sentinel Auth

### DIFF
--- a/src/Cm/RedisSession/Handler/ConfigSentinelPasswordInterface.php
+++ b/src/Cm/RedisSession/Handler/ConfigSentinelPasswordInterface.php
@@ -1,0 +1,41 @@
+<?php
+/*
+==New BSD License==
+
+Copyright (c) 2013, Colin Mollenhour
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The name of Colin Mollenhour may not be used to endorse or promote products
+      derived from this software without specific prior written permission.
+    * Redistributions in any form must not change the Cm_RedisSession namespace.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+namespace Cm\RedisSession\Handler;
+
+interface ConfigSentinelPasswordInterface
+{
+    /**
+     * Get Redis Sentinel password
+     *
+     * @return string|null
+     */
+    public function getSentinelPassword();
+}


### PR DESCRIPTION
A new feature has been added that allows users to set a separate password for Redis Sentinel.