### PR TITLE
🐛 Adding php56 compatibility

### DIFF
--- a/src/Cm/RedisSession/Handler.php
+++ b/src/Cm/RedisSession/Handler.php
@@ -512,7 +512,7 @@ class Handler implements \SessionHandlerInterface
                     // Overloaded sessions get 503 errors
                     $this->_redis->hIncrBy($sessionId, 'wait', -1);
                     $this->_sessionWritten = true; // Prevent session from getting written
-                    [$writes, $lockedRequestUrl] = $this->_redis->hMGet($sessionId, ['writes','req']);
+                    list($writes, $lockedRequestUrl) = $this->_redis->hMGet($sessionId, ['writes','req']);
                     $this->_log(
                         sprintf(
                             'Session concurrency exceeded for ID %s; displaying HTTP 503 (%s waiting, %s total '


### PR DESCRIPTION
The short syntax for the 'list' function was introduced in PHP 7.1. Prior to this version, 'list' was used as a regular function. Our Magento 1.5 projects are currently running on PHP 5.6, which does not support the short syntax. This has resulted in the following error:

```php
<?php

// works
list($a, $b) = [
    'a',
    'b'
];

// dont work
[$a, $b] = [
    'a',
    'b'
];

// Parse error: syntax error, unexpected '=' in /.../test.php on line 10
```